### PR TITLE
Use min() instead of multiply for ground caustics

### DIFF
--- a/src/world/Fish.js
+++ b/src/world/Fish.js
@@ -10,8 +10,8 @@ const fishWaveAmplitude 	= 5.0
 const fishWavelength 		= 0.08
 const fishWaveSpeed 		= 15.0
 const fishTint 				= new THREE.Vector4(1.0, 1.0, 2.2, 1.0)
-const fishCausticsScale		= 0.6 
-const fishCausticsStrength	= 0.6 
+const fishCausticsScale		= 0.5 
+const fishCausticsStrength	= 0.5 
 
 const boidCount 		= 100
 const boidScale 		= 0.01

--- a/src/world/Ground.js
+++ b/src/world/Ground.js
@@ -70,7 +70,7 @@ export default class Ground extends WorldObject
 				#include <map_fragment>
 				vec4 noiseSample1 = texture2D(uCausticsMap, 8.0 * vMapUv + uTime * uSpeed);
 				vec4 noiseSample2 = texture2D(uCausticsMap, 6.0 * vMapUv - uTime * uSpeed);
-				diffuseColor += uCausticsTint * (noiseSample1 * noiseSample2);
+				diffuseColor += uCausticsTint * min(noiseSample1, noiseSample2);
 				`
 			)
 			material.userData.shader = shader

--- a/src/world/Ground.js
+++ b/src/world/Ground.js
@@ -68,8 +68,8 @@ export default class Ground extends WorldObject
 				'#include <map_fragment>',
 				`
 				#include <map_fragment>
-				vec4 noiseSample1 = texture2D(uCausticsMap, 8.0 * vMapUv + uTime * uSpeed);
-				vec4 noiseSample2 = texture2D(uCausticsMap, 6.0 * vMapUv - uTime * uSpeed);
+				vec4 noiseSample1 = texture2D(uCausticsMap, 7.0 * vMapUv + uTime * uSpeed);
+				vec4 noiseSample2 = texture2D(uCausticsMap, 5.0 * vMapUv - uTime * uSpeed);
 				diffuseColor += uCausticsTint * min(noiseSample1, noiseSample2);
 				`
 			)


### PR DESCRIPTION
Creates more accurate spiderweb shapes for caustic projections on ground